### PR TITLE
fix: Remove audio dependencies for Vercel deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ langchain-core==0.1.52
 
 flask
 speechrecognition
-pyttsx3
-pyaudio
 python-dotenv
 websockets
 asyncio-mqtt


### PR DESCRIPTION
This commit removes the `pyaudio` and `pyttsx3` packages from `requirements.txt`.

These packages were causing the build to fail on Vercel because they require system-level audio libraries that are not available in the Vercel build environment. The application is designed to run without these packages when deployed as a web server, so they are not necessary.